### PR TITLE
Add optional support for Gerrit Trigger Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,32 @@
 
   <dependencies>
     <dependency>
+      <groupId>net.sourceforge.htmlunit</groupId>
+      <artifactId>htmlunit</artifactId>
+      <version>2.19</version>
+    </dependency>
+    <dependency>
       <groupId>org.fluentd</groupId>
       <artifactId>fluent-logger</artifactId>
       <version>0.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sonyericsson.hudson.plugins.gerrit</groupId>
+      <artifactId>gerrit-trigger</artifactId>
+      <version>2.15.0</version>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sf.json-lib</groupId>
+          <artifactId>json-lib</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.8.9</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/fluentd/FluentHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/fluentd/FluentHelper.java
@@ -25,7 +25,7 @@ public class FluentHelper {
      * @param jsonFromExtension json that would be used as extension
      * @param jsonFromFile json that would be extend
      * @param startTimeInMillis job start time in milliseconds
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException if specified json can not be parsed.
      */
     static void sendJson(FluentLogger fluentLogger, String tag, Map<String, String> envVars, String jsonFromExtension,
                          String jsonFromFile, long startTimeInMillis) throws IllegalArgumentException {

--- a/src/main/java/org/jenkinsci/plugins/fluentd/FluentLoggerHolder.java
+++ b/src/main/java/org/jenkinsci/plugins/fluentd/FluentLoggerHolder.java
@@ -1,0 +1,25 @@
+package org.jenkinsci.plugins.fluentd;
+
+import org.fluentd.logger.FluentLogger;
+
+import java.util.logging.Logger;
+
+/**
+ * Holds the reference to the current {@link FluentLogger}
+ */
+final class FluentLoggerHolder {
+    private static final Logger LOGGER = Logger.getLogger(FluentLogger.class.toString());
+    private static transient volatile FluentLogger fluentLogger;
+
+    static FluentLogger getLogger() {
+        return fluentLogger;
+    }
+
+    static void initLogger(FluentLogger newLogger) {
+        if (fluentLogger != null) {
+            LOGGER.info("Reset fluent logger");
+        }
+
+        fluentLogger = newLogger;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/fluentd/GerritTriggerPluginListener.java
+++ b/src/main/java/org/jenkinsci/plugins/fluentd/GerritTriggerPluginListener.java
@@ -1,0 +1,92 @@
+package org.jenkinsci.plugins.fluentd;
+
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.extensions.GerritTriggeredBuildListener;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Account;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+import hudson.Extension;
+import hudson.model.Result;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+@Extension(optional = true)
+public class GerritTriggerPluginListener extends GerritTriggeredBuildListener {
+    private static final Logger LOGGER = Logger.getLogger(GerritTriggerPluginListener.class.toString());
+    private static final String GERRIT_TRIGGER_STARTED_TAG = "gerrit_trigger_plugin.on_started";
+    private static final String GERRIT_TRIGGER_COMPLETED_TAG = "gerrit_trigger_plugin.on_completed";
+
+    @Override
+    public void onStarted(GerritTriggeredEvent gerritTriggeredEvent, String command) {
+        if (!OptionalFeaturesHolder.isGerritTriggerPluginListenerEnabled()) {
+            return;
+        }
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("event_type", gerritTriggeredEvent.getEventType().getTypeValue());
+        data.put("command_size", command.length());
+
+        if (gerritTriggeredEvent instanceof ChangeBasedEvent) {
+            addChangeBasedInfo((ChangeBasedEvent) gerritTriggeredEvent, data);
+        }
+
+        FluentLoggerHolder.getLogger().log(GERRIT_TRIGGER_STARTED_TAG, data);
+        LOGGER.fine("OnStarted is logged for event: " + gerritTriggeredEvent.toString());
+    }
+
+    @Override
+    public void onCompleted(Result result, GerritTriggeredEvent gerritTriggeredEvent, String command) {
+        if (!OptionalFeaturesHolder.isGerritTriggerPluginListenerEnabled()) {
+            return;
+        }
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("event_type", gerritTriggeredEvent.getEventType().getTypeValue());
+        data.put("command_size", command.length());
+        data.put("result", result.toString());
+
+        if (gerritTriggeredEvent instanceof ChangeBasedEvent) {
+            addChangeBasedInfo((ChangeBasedEvent) gerritTriggeredEvent, data);
+        }
+
+        FluentLoggerHolder.getLogger().log(GERRIT_TRIGGER_COMPLETED_TAG, data);
+        LOGGER.fine("OnCompleted is logged for event: " + gerritTriggeredEvent.toString());
+    }
+
+    private void addChangeBasedInfo(ChangeBasedEvent changeBasedEvent, Map<String, Object> data) {
+        Change change = changeBasedEvent.getChange();
+
+        data.put("change_id", change.getId());
+        data.put("branch", change.getBranch());
+        data.put("project", change.getProject());
+        data.put("topic", change.getTopic());
+
+        if (change.getCreatedOn() != null) {
+            data.put("change_created_on", change.getCreatedOn().getTime());
+        }
+
+        if (changeBasedEvent.getEventCreatedOn() != null) {
+            data.put("event_created_on", changeBasedEvent.getEventCreatedOn().getTime());
+        }
+
+        PatchSet patchSet = changeBasedEvent.getPatchSet();
+        if (patchSet != null) {
+            data.put("patchset_number", patchSet.getNumber());
+            data.put("patchset_kind", patchSet.getKind().toString());
+
+            if (patchSet.getCreatedOn() != null) {
+                data.put("patchset_created_on", patchSet.getCreatedOn().getTime());
+            }
+        }
+
+        Account changeOwner = change.getOwner();
+        if (changeOwner != null) {
+            data.put("owner_email", changeOwner.getEmail());
+            data.put("owner_name", changeOwner.getName());
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/fluentd/OptionalFeaturesHolder.java
+++ b/src/main/java/org/jenkinsci/plugins/fluentd/OptionalFeaturesHolder.java
@@ -1,0 +1,17 @@
+package org.jenkinsci.plugins.fluentd;
+
+/**
+ * This class holds the optional feature flags.
+ * It's needed because if dependency is marked as optional, you can not access that class outside.
+ */
+public class OptionalFeaturesHolder {
+    private static boolean isGerritTriggerPluginListenerEnabled = false;
+
+    static void setIsGerritTriggerPluginListenerEnabled(boolean enabled) {
+        isGerritTriggerPluginListenerEnabled = enabled;
+    }
+
+    static boolean isGerritTriggerPluginListenerEnabled() {
+        return isGerritTriggerPluginListenerEnabled;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/fluentd/Fluentd/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/fluentd/Fluentd/global.jelly
@@ -22,5 +22,9 @@
       <f:entry title="Port">
         <f:textbox field="port" />
       </f:entry>
+      <f:entry help="/plugin/fluentd/help-GerritTriggerPluginListener.html">
+      <f:checkbox field="enableGerritTriggeredBuildListener" checked="${descriptor.enableGerritTriggeredBuildListener}"/>
+        <label class="attach-previous">Send the data for every onStarted/onCompleted of Gerrit Trigger Plugin Event</label>
+      </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/webapp/help-GerritTriggerPluginListener.html
+++ b/src/main/webapp/help-GerritTriggerPluginListener.html
@@ -1,0 +1,59 @@
+<p><strong>Gerrit Trigger Plugin Listener</strong> allows to subscribe on each build started / validation completed event.</p>
+If listener received change related event (i.e. PatchsetCreated) for <code>onCompleted</code>
+(this event is triggered in the moment when Gerrit Trigger Plugin pushes the vote to the change) it will push to FluentD this data:
+<table border="1" cellpadding="2px">
+    <thead>
+    <tr>
+        <th>Field name</th><th>Example</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>result</td><td>ABORTED</td>
+    </tr>
+    <tr>
+        <td>event_type</td><td>patchset-created</td>
+    </tr>
+    <tr>
+        <td>command_size</td><td>33</td>
+    </tr>
+    <tr>
+        <td>owner_name</td><td>name</td>
+    </tr>
+    <tr>
+        <td>owner_email</td><td>email</td>
+    </tr>
+    <tr>
+        <td>change_id</td><td>change</td>
+    </tr>
+    <tr>
+        <td>project</td><td>project_name</td>
+    </tr>
+    <tr>
+        <td>topic</td><td>topic_name</td>
+    </tr>
+    <tr>
+        <td>branch</td><td>branch_name</td>
+    </tr>
+    <tr>
+        <td>patchset_number</td><td>number</td>
+    </tr>
+    <tr>
+        <td>patchset_kind</td><td>TRIVIAL_REBASE</td>
+    </tr>
+    <tr>
+        <td>change_created_on</td><td>1507274800000</td>
+    </tr>
+    <tr>
+        <td>patchset_created_on</td><td>1507274900000</td>
+    </tr>
+    <tr>
+        <td>event_created_on</td><td>1507275000000</td>
+    </tr>
+    </tbody>
+</table>
+For <code>onStarted</code> (this event is triggered in the moment when Gerrit Trigger Plugin sends information that builds started) it will push the same data except result field.
+<p>In case of not a change related changes (i.e. RefUpdated) only <code>command</code> and <code>result</code> will be sent.
+But it should never happen according the current implementation of GerritTriggerPlugin</p>
+The data for <code>onStarted</code> is pushed with tag <code>gerrit_trigger_plugin.on_started</code>. The <code>onCompleted</code> goes to <code>gerrit_trigger_plugin.on_completed</code>.
+

--- a/src/test/java/org/jenkinsci/plugins/fluentd/GerritTriggerPluginListenerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/fluentd/GerritTriggerPluginListenerTest.java
@@ -1,0 +1,172 @@
+package org.jenkinsci.plugins.fluentd;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeKind;
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventType;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Account;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
+import hudson.model.Result;
+import org.fluentd.logger.FluentLogger;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+public class GerritTriggerPluginListenerTest {
+    private FluentLogger fluentLogger;
+    private GerritTriggerPluginListener listener;
+    private final String COMMAND = "custom command";
+
+    @Before
+    public void setUp() throws Exception {
+        fluentLogger = Mockito.mock(FluentLogger.class);
+
+        listener = new GerritTriggerPluginListener();
+        OptionalFeaturesHolder.setIsGerritTriggerPluginListenerEnabled(false);
+
+        FluentLoggerHolder.initLogger(fluentLogger);
+    }
+
+    @Test
+    public void onStartedAndDisabled() throws Exception {
+        GerritTriggeredEvent gerritTriggeredEvent = Mockito.mock(ChangeBasedEvent.class);
+
+        listener.onStarted(gerritTriggeredEvent, COMMAND);
+
+        verifyZeroInteractions(fluentLogger);
+    }
+
+    @Test
+    public void onCompletedAndDisabled() throws Exception {
+        GerritTriggeredEvent gerritTriggeredEvent = Mockito.mock(ChangeBasedEvent.class);
+
+        listener.onCompleted(Result.ABORTED, gerritTriggeredEvent, COMMAND);
+
+        verifyZeroInteractions(fluentLogger);
+    }
+
+    @Test
+    public void onStartedEnabledLogNotChangedBased() throws Exception {
+        OptionalFeaturesHolder.setIsGerritTriggerPluginListenerEnabled(true);
+        GerritTriggeredEvent gerritTriggeredEvent = getNotChangedBasedEvent();
+
+        listener.onStarted(gerritTriggeredEvent, COMMAND);
+
+        Map<String, Object> expectedData = new HashMap<>();
+        expectedData.put("event_type", "ref-updated");
+        expectedData.put("command_size", 14);
+
+        verify(fluentLogger, times(1)).log(eq("gerrit_trigger_plugin.on_started"), eq(expectedData));
+    }
+
+    @Test
+    public void onCompletedEnabledLogNotChangedBased() throws Exception {
+        OptionalFeaturesHolder.setIsGerritTriggerPluginListenerEnabled(true);
+        GerritTriggeredEvent gerritTriggeredEvent = getNotChangedBasedEvent();
+
+        listener.onCompleted(Result.ABORTED, gerritTriggeredEvent, COMMAND);
+
+        Map<String, Object> expectedData = new HashMap<>();
+        expectedData.put("result", "ABORTED");
+        expectedData.put("event_type", "ref-updated");
+        expectedData.put("command_size", 14);
+
+        verify(fluentLogger, times(1)).log(eq("gerrit_trigger_plugin.on_completed"), eq(expectedData));
+    }
+
+    @Test
+    public void onStartedEnabledLogChangedBased() throws Exception {
+        OptionalFeaturesHolder.setIsGerritTriggerPluginListenerEnabled(true);
+        GerritTriggeredEvent gerritTriggeredEvent = getChangeBasedEvent();
+
+        listener.onStarted(gerritTriggeredEvent, COMMAND);
+
+        Map<String, Object> expectedData = new HashMap<>();
+        expectedData.put("event_type", "patchset-created");
+        expectedData.put("command_size", 14);
+        expectedData.put("owner_name", "name");
+        expectedData.put("owner_email", "email");
+        expectedData.put("change_id", "change");
+        expectedData.put("project", "project_name");
+        expectedData.put("topic", "topic_name");
+        expectedData.put("branch", "branch_name");
+        expectedData.put("patchset_number", "number");
+        expectedData.put("patchset_kind", "TRIVIAL_REBASE");
+        expectedData.put("change_created_on", 5L);
+        expectedData.put("patchset_created_on", 10L);
+        expectedData.put("event_created_on", 15L);
+
+        verify(fluentLogger, times(1)).log(eq("gerrit_trigger_plugin.on_started"), eq(expectedData));
+    }
+
+    @Test
+    public void onCompletedEnabledLogChangedBased() throws Exception {
+        OptionalFeaturesHolder.setIsGerritTriggerPluginListenerEnabled(true);
+        GerritTriggeredEvent gerritTriggeredEvent = getChangeBasedEvent();
+
+        listener.onCompleted(Result.ABORTED, gerritTriggeredEvent, COMMAND);
+
+        Map<String, Object> expectedData = new HashMap<>();
+        expectedData.put("result", "ABORTED");
+        expectedData.put("event_type", "patchset-created");
+        expectedData.put("command_size", 14);
+        expectedData.put("owner_name", "name");
+        expectedData.put("owner_email", "email");
+        expectedData.put("change_id", "change");
+        expectedData.put("project", "project_name");
+        expectedData.put("topic", "topic_name");
+        expectedData.put("branch", "branch_name");
+        expectedData.put("patchset_number", "number");
+        expectedData.put("patchset_kind", "TRIVIAL_REBASE");
+        expectedData.put("change_created_on", 5L);
+        expectedData.put("patchset_created_on", 10L);
+        expectedData.put("event_created_on", 15L);
+
+        verify(fluentLogger, times(1)).log(eq("gerrit_trigger_plugin.on_completed"), eq(expectedData));
+    }
+
+    private GerritTriggeredEvent getNotChangedBasedEvent() {
+        GerritTriggeredEvent gerritTriggeredEvent = Mockito.mock(RefUpdated.class);
+
+        GerritEventType eventType = GerritEventType.REF_UPDATED;
+        when(gerritTriggeredEvent.getEventType()).thenReturn(eventType);
+        return gerritTriggeredEvent;
+    }
+
+    private GerritTriggeredEvent getChangeBasedEvent() {
+        PatchsetCreated patchsetCreated = Mockito.mock(PatchsetCreated.class);
+        Change change = Mockito.mock(Change.class);
+        Account account = Mockito.mock(Account.class);
+        PatchSet patchSet = Mockito.mock(PatchSet.class);
+
+        GerritEventType eventType = GerritEventType.PATCHSET_CREATED;
+        when(patchsetCreated.getEventType()).thenReturn(eventType);
+        when(patchsetCreated.getChange()).thenReturn(change);
+        when(patchsetCreated.getEventCreatedOn()).thenReturn(new Date(15));
+        when(patchsetCreated.getPatchSet()).thenReturn(patchSet);
+
+        when(change.getOwner()).thenReturn(account);
+        when(account.getName()).thenReturn("name");
+        when(account.getEmail()).thenReturn("email");
+        when(change.getCreatedOn()).thenReturn(new Date(5));
+        when(change.getId()).thenReturn("change");
+        when(change.getBranch()).thenReturn("branch_name");
+        when(change.getProject()).thenReturn("project_name");
+        when(change.getTopic()).thenReturn("topic_name");
+        when(patchSet.getNumber()).thenReturn("number");
+        when(patchSet.getKind()).thenReturn(GerritChangeKind.TRIVIAL_REBASE);
+        when(patchSet.getCreatedOn()).thenReturn(new Date(10));
+
+        return patchsetCreated;
+    }
+}
+


### PR DESCRIPTION
After that it would be possible to get quite useful information:
- how much time is needed to get +1 from creating change moment
- how much patch-set do we verify everyday
- every -1/+1 from Gerrit Trigger Plugin
- who creates the most of load
- etc.