### PR TITLE
Use GitHub as a Source of the plugin documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <name>Fluentd Plugin</name>
   <description>A Jenkins plugin which allows to publish JSON data directly to Fluentd</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/FluentD+Plugin</url>
+  <url>https://github.com/jenkinsci/fluentd-plugin</url>
 
   <licenses>
     <license>


### PR DESCRIPTION
FTR https://jenkins.io/blog/2019/10/21/plugin-docs-on-github